### PR TITLE
Change EmailUs to Email as per magento internal config-path

### DIFF
--- a/ViewModel/StoreInfo.php
+++ b/ViewModel/StoreInfo.php
@@ -51,7 +51,7 @@ class StoreInfo implements ArgumentInterface
         return (string) $this->getStoreInfo('phone');
     }
 
-    public function getEmailUs(): string
+    public function getEmail(): string
     {
         return (string) $this->getTransEmail('email');
     }


### PR DESCRIPTION
Internally the name for Email is "email" in Magento, unlike "email_us" .

(The templates will need to be updated)